### PR TITLE
Add requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pygame==2.6.1
+PyQt6==6.8.1
+PyQt6_sip==13.10.0
+PyQt6-QScintilla==2.14.1


### PR DESCRIPTION
For convenience, the presence of a requirements file will allow all requirements to be installed with one command:
```
pip install -r requirements.txt
```