### PR TITLE
Added some commands & parameters & named parameters from docs/index.html

### DIFF
--- a/data/PyWrightScriptLexer.py
+++ b/data/PyWrightScriptLexer.py
@@ -106,10 +106,13 @@ cases = ["_case_{}".format(num) for num in range(100)]
 # Just for that sweet, sweet startswith()
 named_parameters = ("start=", "end=", "e=", "x=", "y=", "z=", "name=", "speed=", "width=", "height=", "rwidth=", "rheight=",
                     "graphic=", "graphichigh=", "examine=", "talk=", "present=", "move=", "fail=", "nametag=", "result=", "label=",
-                    "mag=", "frames=", "hotkey=", "jumpto=","pause=","test=")
+                    "mag=", "frames=", "hotkey=", "jumpto=","pause=","test=", "loops=", "rotz=", "be=", "pri=", "variable=", "threat=",
+                    "delay=", "color=", "run=", "priority=", "prop=", "value=", "degrees=", "axis=", "filter=", "after=")
 
 parameters = ["stack", "nowait", "noclear", "hide", "fade", "true", "false", "noback", "sx", "sy",
-              "blink", "loop", "noloop", "b", "t", "stop", "noauto", "password", "all", "suppress"]
+              "blink", "loop", "noloop", "b", "t", "stop", "noauto", "password", "all", "suppress", "flipx", "wait", "hold", "try_bottom",
+              "script", # This is also a command, so coloring might be wrong
+              "last", "both"]
 
 # Following might need some sort of regex for each
 # "{sound {str}}"

--- a/data/PyWrightScriptLexer.py
+++ b/data/PyWrightScriptLexer.py
@@ -238,7 +238,7 @@ class PyWrightScriptLexer(QsciLexerCustom):
         wasNewLine = True
         for i, token in enumerate(token_list):
             self._set_styling_for_token(token, wasNewLine)
-            wasNewLine = "\n" in token[0].replace('\r', '\n')
+            wasNewLine = '\n' in token[0].replace('\r', '\n') or (wasNewLine and not token[0].strip())
 
     def _set_styling_for_token(self, token: tuple[str, int], isFirstOfLine:bool = False):
         # Handle tokens ending with ?

--- a/data/PyWrightScriptLexer.py
+++ b/data/PyWrightScriptLexer.py
@@ -53,6 +53,13 @@ commands = [
     # Not mentioned in doc.txt, but somewhere else
     "zoom", "char", "delete", "shake", "is_ex", "setvar_ex",
 
+    # Not mentioned in doc.txt but in docs/index.html
+    "filewrite", "screenshot", "bemo", "clear", "textblock", "textbox",
+    "locked_cases", "addcase", "wincase", "resetcase", "examine3d", "localmenu", "region3d",
+    "game", "controlanim", "globaldelay", "gamemenu", "getprop", "setprop", "debug",
+    "fade", # this is also a parameter so coloration might be wrong in some place
+    "grey", "invert", "tint", 
+
     # Misc. stuff (some might be custom macros, or stuff that wasn't in 0.9880)
     "in", "out", "obj"
 ]


### PR DESCRIPTION
I've found in the PyWright installation folder that `docs/index.html` is a documentation file containing some commands and parameters not present in the IDE, so I added them to the list.

However, there are now 2 commands that are also parameters, `fade` and `script`.

Because of that, I made it so that tokens that are both a command and a parameter will be colored as a command
if they are on the beginning of a line (also works with indented lines), and as a parameter otherwise.

As you can see in this image, the `fade` on line 88 is blue like other commands, and the one line 103 is red like other parameters.
<img width="648" height="289" alt="image" src="https://github.com/user-attachments/assets/54b2d899-7e91-4655-b9b8-8b13422001d9" />

