### PR TITLE
Autocompletion is now more contextual than before.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   * Add more parameters from docs/index.html (by Zetrypio)
   * Add distinction for "fade" and "script" depending on where they are used, which can be both a command or a parameter (by Zetrypio)
   * Don't style question marks at the end of comments. (by in1tiate)
-  * Improvment of the Autocompletion support to be more contextual (by Zetrypio)
+  * Make Autocompletion more contextual (by Zetrypio)
 
 ## Version 1.4.2 - 31.05.2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Add more parameters from docs/index.html (by Zetrypio)
   * Add distinction for "fade" and "script" depending on where they are used, which can be both a command or a parameter (by Zetrypio)
   * Don't style question marks at the end of comments. (by in1tiate)
+  * Improvment of the Autocompletion support to be more contextual (by Zetrypio)
 
 ## Version 1.4.2 - 31.05.2025
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -2,7 +2,7 @@
 
 ## Thanks to:
 
-* Zetrypio: Basic autocompletion support, {} tokens colorization in strings.
+* Zetrypio: Autocompletion support, {} tokens colorization in strings.
 * in1tiate: Big improvements to the Script Lexer, plus improvements to Find/Replace dialog.
 * Everyone on the [Court Records forums thread](https://forums.court-records.net/viewtopic.php?f=36&t=33857) who provided their feedback!
 

--- a/data/PyWrightScriptLexer.py
+++ b/data/PyWrightScriptLexer.py
@@ -147,6 +147,40 @@ def is_string_float(string: str) -> bool:
         return False
 
 
+class CustomQsciAPIs(QsciAPIs):
+    
+    def __init__(self, lexer:'QsciLexer')->None:
+        super().__init__(lexer)
+ 
+    def updateAutoCompletionList(self, context:[str], list:[str])->[str]:
+        line, index = self.lexer().parent().getCursorPosition()
+        text = self.lexer().parent().text(line).strip()
+
+        # Comments:
+        if text.startswith("#") or text.startswith("//"):
+            return []
+
+        # Strings:
+        if text.startswith('"'):
+            return string_tokens
+
+        # Test whether we are in command area or in parameters area
+        split = text.split(" ")
+
+        # Commands:
+        if len(split) == 1:
+            for l in (commands, self.lexer().builtin_macros, self.lexer().game_macros):
+                list += l
+
+        # Parameters:
+        # TODO for the future: make the parameter list dependent on the command name
+        else:
+            for l in (special_variables, named_parameters, parameters, logic_operators):
+                list += l
+
+        return list
+
+
 class PyWrightScriptLexer(QsciLexerCustom):
 
     def __init__(self, parent: QsciScintilla):
@@ -166,19 +200,12 @@ class PyWrightScriptLexer(QsciLexerCustom):
         self.setup_autocompletion()
 
     def setup_autocompletion(self):
-        # Create an API for us to populate with our autocomplete terms
-        api = QsciAPIs(self)
-
-        # Add autocompletion strings
-        for l in (commands, special_variables, named_parameters, parameters, string_tokens, logic_operators, self.builtin_macros, self.game_macros):
-            for c in l:
-                api.add(c)
-
-        # Compile the api for use in the lexer
+        # Create a custom API for us to populate with our autocomplete terms
+        api = CustomQsciAPIs(self)
         api.prepare()
 
     def wordCharacters(self)->str:
-        # The important thing in this string, is to add the {} near the end.
+        # The important thing in this string, is to be sure to have the {} in it.
         # That way, {} tokens in string can have their autocompletion.
         return "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789{}"
 

--- a/data/PyWrightScriptLexer.py
+++ b/data/PyWrightScriptLexer.py
@@ -113,13 +113,7 @@ parameters = ["stack", "nowait", "noclear", "hide", "fade", "true", "false", "no
               "script", "last", "both"]
 
 # Following might need some sort of regex for each
-# "{sound {str}}"
-# "{c{number}}
-# "{p{number}}
-# "{delay {number}}
-# "{sfx {str}}
-# "{s {str}}"
-string_tokens = ["{n}", "{next}", "{f}", "{center}"]
+string_tokens = ["{n}", "{next}", "{f}", "{center}", "{sound /}", "{c}", "{p}", "{delay 1}", "{sfx /}", "{s }", "{spd}", "{e}"]
 
 # Logical operators
 logic_operators = ["==", "<=", ">=", "<", ">", "NOT", "AND", "OR"]

--- a/data/PyWrightScriptLexer.py
+++ b/data/PyWrightScriptLexer.py
@@ -148,7 +148,7 @@ class CustomQsciAPIs(QsciAPIs):
  
     def updateAutoCompletionList(self, context:[str], list:[str])->[str]:
         line, index = self.lexer().parent().getCursorPosition()
-        text = self.lexer().parent().text(line).strip()
+        text = self.lexer().parent().text(line).lstrip()
 
         # Comments:
         if text.startswith("#") or text.startswith("//"):

--- a/data/PyWrightScriptLexer.py
+++ b/data/PyWrightScriptLexer.py
@@ -177,6 +177,11 @@ class PyWrightScriptLexer(QsciLexerCustom):
         # Compile the api for use in the lexer
         api.prepare()
 
+    def wordCharacters(self)->str:
+        # The important thing in this string, is to add the {} near the end.
+        # That way, {} tokens in string can have their autocompletion.
+        return "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789{}"
+
     def set_font_properties(self, font_name: str, font_size: int, bold_font: bool):
         self.setDefaultFont(QFont(font_name, font_size))
         font_weight = QFont.Weight.Bold if bold_font else QFont.Weight.Normal


### PR DESCRIPTION
Now, the auto-completion will:
 - stop proposing anything inside comments;
 - only propose for {} tokens inside of strings;
 - only propose commands & macros when in the beginning of a line (ignoring indentation);
 - only propose parameters when after the first (non-indent) space of the line.

I also added back some of the string tokens in the list, because they are now used for auto-completion as well. There might be  a few that are missing, and I'm not really sure how to present the completion for those that have parameters in them.

This new auto-completion is more contextual, which should less annoy people by constantly proposing things they don't want, especially in strings.

Also, I needed for that to make a custom API class, should I move it to a new file? If so, which folder should I put it in? And maybe also rename it to something with PyWright in its name?

The next step to make this better would be to propose only the appropriate parameters depending on the command, but that will require a lot more work.

I was wondering where would be an appropriate place for us to discuss more about how to implement that nicely, as it will probably need a little bit of refactoring (or maybe just figuring out what is the best solution).