### PR TITLE
Switch to Pygame Community, unpin PyQt6 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pygame==2.6.1
-PyQt6==6.10.0
-PyQt6_sip==13.10.2
-PyQt6-QScintilla==2.14.1
+pygame-ce>=2.5.6
+PyQt6>=6.10.0
+PyQt6_sip>=13.10.2
+PyQt6-QScintilla>=2.14.1


### PR DESCRIPTION
[pygame-ce](https://github.com/pygame-community/pygame-ce) has better support for newer versions of Python and is under active development. Also unpinned PyQt related requirements; they don't need to be pinned