### PR TITLE
Fixed a crash when opening a text file when an image viewer is already opened.

### DIFF
--- a/gui/MainWindowCentralWidget.py
+++ b/gui/MainWindowCentralWidget.py
@@ -108,8 +108,8 @@ class MainWindowCentralWidget(QWidget):
         file_name = Path(file_path).name
         # Append folder name if two tabs with the same name are open
         for i in range(self.tab_widget.count()):
-            # Skip Game Properties tab
-            if self.is_game_properties_tab(i):
+            # Skip Game Properties tab and image viewer tabs
+            if not self.is_file_editing_tab(i):
                 continue
 
             opened_tab: FileEditWidget = self.tab_widget.widget(i)


### PR DESCRIPTION
Fixed a crash when opening a text file when an image viewer is already opened.

This was the crash: 
<img width="369" height="314" alt="image" src="https://github.com/user-attachments/assets/77c421f0-f3e4-4da8-bc44-b94e213057c6" />
